### PR TITLE
Update CalculatedLiterals.peg.inc

### DIFF
--- a/examples/CalculatedLiterals.peg.inc
+++ b/examples/CalculatedLiterals.peg.inc
@@ -1,6 +1,6 @@
 <?php
 
-require_once dirname(__DIR__).'/autoloader.php';
+require_once __DIR__.'/autoloader.php';
 use hafriedlander\Peg\Parser;
 
 class CalculatedLiterals extends Parser\Basic {


### PR DESCRIPTION
`require_once dirname(__DIR__).'/autoloader.php';`
will lose the dirctory name(php-peg) and generated php script will contain a error.

it should be  
`require_once __DIR__.'/autoloader.php';`
