### PR TITLE
fix tokenizer to parse regexp modifier as part of the regular expression

### DIFF
--- a/lib/hafriedlander/Peg/Compiler/Rule.php
+++ b/lib/hafriedlander/Peg/Compiler/Rule.php
@@ -135,7 +135,7 @@ class Rule extends PHPWriter {
 		((\\\\\\\\)*\\\\/) # Escaped \/, making sure to catch all the \\ first, so that we dont think \\/ is an escaped /
 		|
 		[^/]               # Anything except /
-	)*/@xu' ;
+	)*/\S*(?=\s|$)@xu' ;
 
 	function tokenize( $str, &$tokens, $o = 0 ) {
 		$length = strlen($str);


### PR DESCRIPTION
This
- allows to use modifiers like 'u' (for unicode support) to be used.
- makes the Rfc822UTF8.peg.inc example working again.

This change might break regexp rules not followd
by a whitespace or a line-end.
