### PR TITLE
Disable PCRE JIT compilation

### DIFF
--- a/cli.php
+++ b/cli.php
@@ -1,4 +1,5 @@
 <?php
+ini_set("pcre.jit", "0");
 
 require 'autoloader.php';
 


### PR DESCRIPTION
This fixes generation when using PHP7. Without this, no output is generated at all (for certain input files).

Resolves #35.
