### PR TITLE
Escape single quotes

### DIFF
--- a/lib/hafriedlander/Peg/Compiler/Token/Literal.php
+++ b/lib/hafriedlander/Peg/Compiler/Token/Literal.php
@@ -6,7 +6,9 @@ use hafriedlander\Peg\Compiler\PHPBuilder;
 
 class Literal extends Expressionable {
 	function __construct( $value ) {
-		parent::__construct( 'literal', "'" . substr($value,1,-1) . "'" );
+		// escape single quotes
+		$escaped_value = str_replace('\'', '\\\'', substr($value,1,-1));
+		parent::__construct( 'literal', "'" . $escaped_value . "'" );
 	}
 
 	function match_code( $value ) {


### PR DESCRIPTION
Hello!

Single quotes in a literal would cause the PEG to crash with:
```
PHP Parse error:  syntax error, unexpected '';' (T_ENCAPSED_AND_WHITESPACE), expecting ';'
```

This happens because the literal gets `eval()`ed to check if it's a single character.

This patch escapes the quotes, and the parser gets generated correctly.